### PR TITLE
 Handling postman's folders to help organize docs. 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,3 +21,37 @@ code {
     padding-bottom: 1em;
     border-top: 1px solid #eee;
 }
+/**
+EXTENDED VERB METHODS COLOR SCHEME
+**/
+.label-post{
+    background-color: #5bc0de;
+}
+
+.label-put{
+    background-color: #f0ad4e;
+}
+
+.label-delete{
+    background-color: #d9534f;
+}
+
+.label-get{
+    background-color: #5cb85c;
+}
+
+.label-patch{
+    background-color: #AA9A66;
+
+}
+
+.label-head{
+    background-color: #ca30d2;
+
+}
+
+.label-options{
+    background-color: #000073;
+
+}
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "toptal_task",
   "dependencies": {
     "moment": "^2.9.0",
+    "underscore":"~1.8",
     "react": "^0.12.2",
     "react-bootstrap": "^0.16.1",
     "react-infinite-scroll": "^0.1.5",


### PR DESCRIPTION
Hi. this was really useful to me, so I made some small changes to get more organized docs for myself. Sending a pull request just in case you think this changes could be useful to other people. 
- Handling postman's folders so the doc is a bit more organized. Now you get a header with the folder name and the endpoints for that folder go inside it . If there is no folder, you just don't get a folder title. 
- Added classes for each verb instead of using the bootstrap default ones (but still kept the original colors for verbs). Added more verbs/methods,too. 
- Added underscore to easily filter and manipulate data. 
